### PR TITLE
Move workflow jobs to the fleet runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
 
     name: Foundry project
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Replaces hard-coded ubuntu-latest with [self-hosted, linux, x64]: hosted-runner minutes bill the org while the fleet runner is free, and the estate has migrated CI to it (BloclabsHQ/github-actions#80)
- setup-node provisions its own toolchain, so no runner host changes are needed

## Test plan
- The next workflow run executes on the fleet runner under the same checks